### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If something goes wrong, by creating a new user on your distribution, you won't 
 ### Arch-based distributions
 ```bash
 sudo pacman -S curl python3-pip flatpak svn gnome-menus kitty wget git neofetch npm nodejs btop gnome-menus gnome-shell-extensions
-sudo pip3 install pywal
+sudo pacman -S python-pywal
 ```
 It is also suggested to install `webapp-manager` and `gnome-terminal-transparency` from the AUR.
 


### PR DESCRIPTION
Update the readme to change to the correct way of installing python packages on arch by not using pip. and changing to sudo pacman -S python-pywal